### PR TITLE
Mark assembly as CLS compliant

### DIFF
--- a/NUnit.System.Linq.sln
+++ b/NUnit.System.Linq.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Folder", "Solution
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
 		build.cake = build.cake
+		nuget\NUnit.System.Linq.nuspec = nuget\NUnit.System.Linq.nuspec
 	EndProjectSection
 EndProject
 Global

--- a/src/NUnit.System.Linq/NUnit.System.Linq.csproj
+++ b/src/NUnit.System.Linq/NUnit.System.Linq.csproj
@@ -64,7 +64,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="nunit.snk" />
-    <None Include="NUnit.System.Linq.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/NUnit.System.Linq/Properties/AssemblyInfo.cs
+++ b/src/NUnit.System.Linq/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -34,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.2.0.0")]
 [assembly: AssemblyFileVersion("0.2.0.0")]
+
+[assembly: CLSCompliant(true)]


### PR DESCRIPTION
This assembly should be marked CLS compliant - not being so has introduced build warnings in the main NUnit solution.

This is a step towards nunit/nunit#995
